### PR TITLE
Feature/explicit nullable param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2025-05-29
+
+### Changed
+- Removed deprecated explicit nullable parameter in `HttpLog::log
+- Updated log message in `HttpLog::formatBody` from 'Failed empty response body' to 'Failed empty body'
+
 ## [2.0.2] - 2025-05-23
 
 ### Changed

--- a/src/HttpLog.php
+++ b/src/HttpLog.php
@@ -18,7 +18,7 @@ readonly class HttpLog
 
     public function log(
         RequestInterface $request,
-        ResponseInterface $response = null,
+        ?ResponseInterface $response = null,
         ?Throwable $exception = null,
         ?TransferStats $stats = null,
     ): void {
@@ -100,7 +100,7 @@ readonly class HttpLog
         }
 
         if (strlen($body) === 0) {
-            return 'Failed empty response body';
+            return 'Failed empty body';
         }
 
         return 'Failed to decode JSON from body: '.self::bodySummary($body);

--- a/tests/Unit/HttpLogMiddlewareTest.php
+++ b/tests/Unit/HttpLogMiddlewareTest.php
@@ -216,7 +216,7 @@ class HttpLogMiddlewareTest extends TestCase
         $this->assertSame('Guzzle HTTP Response', $this->logger->records[1]['message']);
 
         $responseContext = $this->logger->records[1]['context']['response'];
-        $this->assertSame('Failed empty response body', $responseContext['body']);
+        $this->assertSame('Failed empty body', $responseContext['body']);
     }
 
     public function test_logs_summary_when_json_decode_fails_and_truncates_body(): void


### PR DESCRIPTION
- [x] Removed deprecated explicit nullable parameter in HttpLog::log
- [x] Updated log message in `HttpLog::formatBody` from 'Failed empty response body' to 'Failed empty body'
